### PR TITLE
Editorconfig

### DIFF
--- a/Plugins/EditorConfig/PluginMain.cs
+++ b/Plugins/EditorConfig/PluginMain.cs
@@ -326,23 +326,23 @@ namespace EditorConfig
         /// <summary>
         /// Helper method to make sure original settings are handled correctly
         /// </summary>
-        /// <param name="GetConfigOption">Getter function for the config option that should be processed</param>
+        /// <param name="getConfigOption">Getter function for the config option that should be processed</param>
         /// <param name="original">The original value of the setting, should be null if no setting was backuped yet</param>
-        /// <param name="GetSetting">Getter function for PluginCore.Setting.YourSetting</param>
-        /// <param name="ApplyOriginal">Applies the original settings if the document is not affected by .editorconfig</param>
-        /// <param name="ApplierFunc">Applies the config option. Is only called if <code>getConfigOption() != null</code></param>
-        static void Apply<S, T>(Func<S> GetConfigOption, ref T? original, Func<T> GetSetting, Action<T> ApplyOriginal, Action ApplierFunc) where T : struct
+        /// <param name="getSetting">Getter function for PluginCore.Setting.YourSetting</param>
+        /// <param name="applyOriginal">Applies the original settings if the document is not affected by .editorconfig</param>
+        /// <param name="applierFunc">Applies the config option. Is only called if <code>getConfigOption() != null</code></param>
+        void Apply<S, T>(Func<S> getConfigOption, ref T? original, Func<T> getSetting, Action<T> applyOriginal, Action applierFunc) where T : struct
         {
-            if (GetConfigOption() != null) //document affected by .editorconfig
+            if (getConfigOption() != null) //document affected by .editorconfig
             {
                 if (original == null) //we have no backup yet
-                    original = GetSetting(); //backup
+                    original = getSetting(); //backup
 
-                ApplierFunc();
+                applierFunc();
             }
             else if (original != null) //document not affected and we have saved settings from before
             {
-                ApplyOriginal((T) original); //restore
+                applyOriginal((T) original); //restore
             }
         }
 

--- a/Plugins/EditorConfig/PluginMain.cs
+++ b/Plugins/EditorConfig/PluginMain.cs
@@ -326,23 +326,23 @@ namespace EditorConfig
         /// <summary>
         /// Helper method to make sure original settings are handled correctly
         /// </summary>
-        /// <param name="getConfigOption">Getter function for the config option that should be processed</param>
+        /// <param name="GetConfigOption">Getter function for the config option that should be processed</param>
         /// <param name="original">The original value of the setting, should be null if no setting was backuped yet</param>
-        /// <param name="getSetting">Getter function for PluginCore.Setting.YourSetting</param>
-        /// <param name="applyOriginal">Applies the original settings if the document is not affected by .editorconfig</param>
-        /// <param name="applierFunc">Applies the config option. Is only called if <code>getConfigOption() != null</code></param>
-        void Apply<S, T>(Func<S> getConfigOption, ref T? original, Func<T> getSetting, Action<T> applyOriginal, Action applierFunc) where T : struct
+        /// <param name="GetSetting">Getter function for PluginCore.Setting.YourSetting</param>
+        /// <param name="ApplyOriginal">Applies the original settings if the document is not affected by .editorconfig</param>
+        /// <param name="ApplierFunc">Applies the config option. Is only called if <code>getConfigOption() != null</code></param>
+        static void Apply<S, T>(Func<S> GetConfigOption, ref T? original, Func<T> GetSetting, Action<T> ApplyOriginal, Action ApplierFunc) where T : struct
         {
-            if (getConfigOption() != null) //document affected by .editorconfig
+            if (GetConfigOption() != null) //document affected by .editorconfig
             {
                 if (original == null) //we have no backup yet
-                    original = getSetting(); //backup
+                    original = GetSetting(); //backup
 
-                applierFunc();
+                ApplierFunc();
             }
             else if (original != null) //document not affected and we have saved settings from before
             {
-                applyOriginal((T) original); //restore
+                ApplyOriginal((T) original); //restore
             }
         }
 

--- a/Plugins/HaxeCheckStyle/HaxeCheckStyle.csproj
+++ b/Plugins/HaxeCheckStyle/HaxeCheckStyle.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HaxeCheckStyle</RootNamespace>
     <AssemblyName>HaxeCheckStyle</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
Fixed ApplyIndentation. ApplyTrimWhitespace was okay, because the setting is only applied when saving the file, so it does not have to be applied to Scintilla. Also changed to backup / restore settings behaviour
Also updated HaxeCheckStyle to .Net 4